### PR TITLE
Fix log4js and pm2 integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ RUN npm i --production
 
 # Install pm2 so we can run our application
 RUN npm i -g pm2
+# Install pm2-intercom for log4js
+RUN pm2 install pm2-intercom
 
 # Add application files
 ADD . /var/www/app/current

--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ module.exports = {redis: r};
 // Initialize logger
 const log4js = require('log4js');
 log4js.configure({
+	pm2: true,
 	appenders: {
 		out: {
 			type: 'console',


### PR DESCRIPTION
Log4js now properly supports pm2 using pm2-intercom
This fixed the issue where no logs were showing up when running with pm2

Testing:
- [x] Manual testing on zordon
